### PR TITLE
refactor: 챗봇 대화 저장 로직 수정

### DIFF
--- a/src/pages/ChatbotPage/ChatbotModal.jsx
+++ b/src/pages/ChatbotPage/ChatbotModal.jsx
@@ -36,13 +36,8 @@ export default function ChatbotModal({ onClose }) {
 
   const handleResetMessages = () => {
     socketRef.current?.emit('force-end-session');
-    const greeting = {
-      role: 'assistant',
-      content: getGreetingText(),
-      type: 'bot',
-      timestamp: new Date(),
-    };
-    setMessages([greeting]);
+    setMessages([]); // 클라이언트 상태만 초기화됨
+    initializeGreetingAndFAQ(); // DB에도 인사말 + 추천질문 저장됨
     setIsChatEnded(false);
   };
 
@@ -68,35 +63,29 @@ export default function ChatbotModal({ onClose }) {
       const greetingText = getGreetingText();
       const quickText = `이런 질문은 어떠세요?\n- ${selected.join('\n- ')}`;
 
-      socketRef.current?.emit('stream-start', { role: 'assistant', content: greetingText });
-      socketRef.current?.emit('stream-end', {
-        message: { role: 'assistant', content: greetingText, type: 'text' },
-      });
-
-      setTimeout(() => {
-        socketRef.current?.emit('stream-start', { role: 'assistant', content: quickText });
-        socketRef.current?.emit('stream-end', {
-          message: { role: 'assistant', content: quickText, type: 'text' },
-        });
-      }, 300);
-
+      // DB 저장 없이 UI에만 보여주기
       setMessages([
-        { id: 'greeting', type: 'bot', content: greetingText, role: 'assistant' },
+        {
+          id: 'greeting',
+          type: 'bot',
+          role: 'assistant',
+          content: greetingText,
+        },
         {
           id: 'quick-questions',
           type: 'bot',
-          content: (
-            <ChatbotQuickQuestionBubble onSelect={handleQuickQuestion} questions={selected} />
-          ),
           role: 'assistant',
+          content: (
+            <ChatbotQuickQuestionBubble questions={selected} onSelect={handleQuickQuestion} />
+          ),
         },
       ]);
+
       setIsChatEnded(false);
     } catch (err) {
       console.error('❌ 초기 인사말 구성 실패:', err);
     }
   };
-
   useEffect(() => {
     const lastMsg = messages.at(-1);
     console.log('📦 마지막 메시지:', lastMsg);


### PR DESCRIPTION
- 사용자가 입력 없이 챗봇을 닫은 경우, 다음 방문 시 이전 대화를 불러오지 않고 초기 인사말 + 추천 질문을 보여줌
- DB에는 인사말 및 추천 질문은 저장하지 않음
- 사용자 입력이 있는 경우에만 이전 대화를 복원함
